### PR TITLE
Hotfix mutex files

### DIFF
--- a/src/system/Component.php
+++ b/src/system/Component.php
@@ -18,7 +18,7 @@ use Cache\Adapter\Filesystem\FilesystemCachePool;
 use Exception;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
-use Monolog\Handler\StreamHandler;
+use Monolog\Handler\ErrorLogHandler;
 use Monolog\Logger;
 use NovemBit\i18n\system\helpers\Arrays;
 use Psr\Log\LoggerInterface;
@@ -269,19 +269,14 @@ abstract class Component implements interfaces\Component
     {
         if (!isset($this->logger)) {
             /**
-             * Runtime directory
-             *
-             * @see $runtime_dir
+             * Log via standard PHP error_log by default. Consumer can `setLogger` as required.
              **/
             $path = trim(str_replace('\\', '/', static::class), '/');
             $log_dir = $this->getRuntimeDir() . "/logs/" . $path;
             $log_file = $log_dir . '/' . date("Y-m-d") . '.log';
             $logger = new Logger('default');
             $logger->pushHandler(
-                new StreamHandler(
-                    $log_file,
-                    $this->logging_level
-                )
+                new ErrorLogHandler()
             );
             $this->setLogger($logger);
         }


### PR DESCRIPTION
Couple of hotfix patches here that help prevent warnings on our production pods.

* The main issue is that by default it attempts to create mutex files in places it doesn't necessarily have guaranteed write access to. The mutex files are a very useful precaution intended to prevent repeat calls to the Google API for requests that have recently failed, which helps to preserve our Translations API quota. Actual behaviour is that it attempts to write a mutex file but can't (creating *lots* of PHP warnings in the logs!) and returns to caller. Next time it comes to retry that translation there is no mutex file to prevent the doomed call from being repeated within the TTL.

  The patch works around the problem by simply using the PHP system-provided temporary directory for mutex files, which is almost certain to exist and be writable in 99.9% of cases, doesn't need any extra configuration (*1), and doesn't require adding extra `is_writable` and 'is_dir` calls before use etc. 

* The second issue is that by default it attempts to create log files in places it doesn't necessarily have guaranteed write access to. This is a problem for us as we run in a containerised/orchestrated environment, and the centralised logging system scrapes output/error logs from the containers. This means centralised logging works just fine out-of-the box if the applications being hosted simply use PHP's 'error_log' (or their equivalent route to /dev/stdout or /dev/stderr), but needs a lot more configuration if applications feel the need to create their own log files all over the place, iyswim.

  So, this part just sets the default Logger to simply use 'error_log', to avoid the need for everyone to have to configure yet more log file directories, permissions, rotation etc etc. :wink:
